### PR TITLE
Self-Service Profile Endpoint: GET + PATCH + Integration Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ build/
 
 ### additional Ignores ###
 *.log*
-logs/*
+/logs/*

--- a/src/main/java/com/reminder/ADR/ADR003.md
+++ b/src/main/java/com/reminder/ADR/ADR003.md
@@ -1,0 +1,29 @@
+# ADR003: Use `userId` from SecurityContext Instead of Redundant DB Query
+
+**Status**: Accepted  
+**Date**: 2025-08-01
+
+## Context
+
+The `CustomUserDetails` class, which is stored in the `SecurityContext` during authentication, includes the `userId` field alongside the `userName` and `role`. Despite this, the code in some services redundantly queried the database using `userName` just to retrieve the user ID.
+
+This issue became evident while implementing authenticated self-service operations (e.g., updating user profile), which rely on `userId` to match foreign keys in other tables like `user_crm`.
+
+## Decision
+
+We refactored the controller logic to extract the `userId` directly from the `SecurityContext`, avoiding unnecessary DB lookups.
+
+Example:
+```java
+Long userId = ((CustomUserDetails) SecurityContextHolder.getContext()
+        .getAuthentication().getPrincipal()).getUserId();
+```
+This leverages the information already present in the authenticated session.
+
+Consequences
+------------
+
+* ✅ Avoids redundant queries to fetch user ID
+* ✅ Reduces coupling between layers (controller and DB)
+* ⚠ Requires explicit casting to `CustomUserDetails`
+* ⚠ Tightens coupling to the current security implementation (acceptable for now)

--- a/src/main/java/com/reminder/ADR/ADR004.md
+++ b/src/main/java/com/reminder/ADR/ADR004.md
@@ -1,0 +1,42 @@
+### ADR003: Merging Partial Profile Updates Before Persisting
+
+**Status**: Accepted  
+**Date**: 2025-08-03  
+**Context**:  
+The `UserUpdateDTO` used in the self-service profile update may contain only a subset of fields (e.g., only email or mobile). If null fields are blindly persisted, they may overwrite existing data in the database with `NULL`. Additionally, the `serviceLevel` calculation logic relies on both fields being present to determine the correct level (1–3).
+
+**Decision**:  
+When updating the user's profile:
+- Retrieve the existing profile from the database using the user's ID.
+- For each field in `UserUpdateDTO`, if it is `null` or empty, replace it with the corresponding value from the existing profile.
+- This merged DTO is then used to:
+    - Recalculate the `serviceLevel` correctly.
+    - Pass to the repository for update.
+
+This approach ensures:
+- No accidental overwrites of missing fields.
+- Accurate service level determination based on a complete data set.
+
+**Implementation Summary**:
+```java
+public void updateMyProfile(Long userId, UserUpdateDTO detailsDTO) {
+    validateUpdateDetails(detailsDTO);
+    detailsDTO = mergeProfiles(detailsDTO, userId);
+    detailsDTO.setServiceLevel(determineServiceLevel(detailsDTO.getEmail(), detailsDTO.getMobile()));
+    usersRepository.updateMyProfile(userId, detailsDTO);
+}
+
+private UserUpdateDTO mergeProfiles(UserUpdateDTO newProfile, long id){
+    UserCrm existingProfile = usersRepository.getUserProfileById(id);
+    if (newProfile.getEmail() == null || newProfile.getEmail().isEmpty())
+        newProfile.setEmail(existingProfile.getEmail());
+    if (newProfile.getMobile() == null || newProfile.getMobile().isEmpty())
+        newProfile.setMobile(existingProfile.getMobile());
+    return newProfile;
+}
+```
+Consequences:
+-
+* Adds a DB query per profile update to fetch existing values.
+* Ensures that updates are safe and partial inputs don’t cause unintended data loss.
+* Improves accuracy of logic that depends on multiple fields (like service level).

--- a/src/main/java/com/reminder/Users/controller/UsersController.java
+++ b/src/main/java/com/reminder/Users/controller/UsersController.java
@@ -5,11 +5,13 @@ import com.reminder.Users.service.UsersService;
 import com.reminder.Users.utilities.JwtUtil;
 import com.reminder.utilities.LogUtil;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -65,7 +67,7 @@ public class UsersController {
         }
     }
 
-    @PreAuthorize("hasRole('user') or hasRole('admin')")
+    @PreAuthorize("hasRole('user') or hasRole('admin') or hasRole(app)")
     @PostMapping("/auth/login")
     public ResponseEntity<?> login (@RequestBody UserLogin user) {
         try {
@@ -79,4 +81,46 @@ public class UsersController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Mmmm this is awkward... Shouldn't happen. Please raise a ticket. log ID: " + uuid);
         }
     }
+
+    @PreAuthorize("hasRole('user') or hasRole('admin')")
+    @PatchMapping("/self_service")
+    public ResponseEntity<?> editMyself (@Valid @RequestBody UserUpdateDTO detailsDTO,
+                                         HttpServletRequest request){
+        RequestContextDTO contextDTO = (RequestContextDTO) request.getAttribute("context");
+        try {
+            detailsDTO.setServiceLevel(0);
+            String userName = SecurityContextHolder.getContext().getAuthentication().getName();
+            contextDTO.setUserName(userName);
+            usersService.updateMyProfile(userName, detailsDTO);
+            logUtil.infoLog(userName, "has successfully updated profile");
+            contextDTO.setOutcome("[SUCCESS] status: 200, User profile updated");
+            return ResponseEntity.status(HttpStatus.OK).body("User updated");
+        }catch (IllegalArgumentException e){
+            contextDTO.setOutcome("[REJECTED] status 400, " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }catch (Exception e){
+            contextDTO.setOutcome("[REJECTED] status 500, " + e.getMessage());
+            String uuid = logUtil.error(e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Mmmm this is awkward... Shouldn't happen. Please raise a ticket. log ID: " + uuid);
+        }
+    }
+
+    @PreAuthorize("hasRole('user') or hasRole('admin')")
+    @GetMapping("/self_service")
+    public ResponseEntity<?> LoadProfile (HttpServletRequest request){
+        RequestContextDTO contextDTO = (RequestContextDTO) request.getAttribute("context");
+        try {
+            String userName = SecurityContextHolder.getContext().getAuthentication().getName();
+            contextDTO.setUserName(userName);
+            UserCrm myProfile = usersService.viewMyProfile(userName);
+            logUtil.infoLog(userName, "profile was successfully loaded by user");
+            contextDTO.setOutcome("[SUCCESS] status: 200, User profile viewed by user");
+            return ResponseEntity.status(HttpStatus.OK).body(myProfile);
+        }catch (Exception e){
+            contextDTO.setOutcome("[REJECTED] status 500, " + e.getMessage());
+            String uuid = logUtil.error(e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Mmmm this is awkward... Shouldn't happen. Please raise a ticket. log ID: " + uuid);
+        }
+    }
+
 }

--- a/src/main/java/com/reminder/Users/model/UserCrm.java
+++ b/src/main/java/com/reminder/Users/model/UserCrm.java
@@ -13,7 +13,7 @@ import java.time.Instant;
 public class UserCrm {
     @Id
     @GeneratedValue (strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
     @NotNull
     @Size(min = 3, max = 20)
     @Pattern(regexp = "^[a-zA-Z]+( [a-zA-Z]+)*$")
@@ -37,6 +37,16 @@ public class UserCrm {
     private Instant lastSeen;
 
     public UserCrm() {
+    }
+
+    public UserCrm(Long id, String givenName, String surname, String email, String mobile, int serviceLevel, Instant lastSeen) {
+        this.id = id;
+        this.givenName = givenName;
+        this.surname = surname;
+        this.email = email;
+        this.mobile = mobile;
+        this.serviceLevel = serviceLevel;
+        this.lastSeen = lastSeen;
     }
 
     public long getId() {

--- a/src/main/java/com/reminder/Users/model/UserUpdateDTO.java
+++ b/src/main/java/com/reminder/Users/model/UserUpdateDTO.java
@@ -1,0 +1,41 @@
+package com.reminder.Users.model;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+
+public class UserUpdateDTO {
+    @Size(max = 40)
+    @Email
+    @Column(name = "email_address", unique = true)
+    private String email;
+    @Size(min = 10, max = 15)
+    @Column(name = "mobile")
+    private String mobile;
+    @Column(name = "service_level")
+    private int serviceLevel;
+
+    public @Size(max = 40) @Email String getEmail() {
+        return email;
+    }
+
+    public void setEmail(@Size(max = 40) @Email String email) {
+        this.email = email;
+    }
+
+    public @Size(min = 10, max = 15) String getMobile() {
+        return mobile;
+    }
+
+    public void setMobile(@Size(min = 10, max = 15) String mobile) {
+        this.mobile = mobile;
+    }
+
+    public int getServiceLevel() {
+        return serviceLevel;
+    }
+
+    public void setServiceLevel(int serviceLevel) {
+        this.serviceLevel = serviceLevel;
+    }
+}

--- a/src/main/java/com/reminder/Users/model/UserUpdateDTO.java
+++ b/src/main/java/com/reminder/Users/model/UserUpdateDTO.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public class UserUpdateDTO {
     @Size(max = 40)
-    @Email
+    @Email (message = "Invalid E-mail address")
     @Column(name = "email_address", unique = true)
     private String email;
     @Size(min = 10, max = 15)

--- a/src/main/java/com/reminder/Users/repository/UsersRepository.java
+++ b/src/main/java/com/reminder/Users/repository/UsersRepository.java
@@ -80,23 +80,25 @@ public class UsersRepository {
         jdbcTemplate.update(sql, id, userName);
     }
 
-    public void updateMyProfile(String userName, UserUpdateDTO detailsDTO) {
-        String sql = String.format("UPDATE %s SET email_address = ?, mobile = ?, service_level = ?, last_seen = ? WHERE user_name = %s", CRM, userName);
+    public void updateMyProfile(Long userId, UserUpdateDTO detailsDTO) {
+        String sql = String.format("UPDATE %s SET email_address = ?, mobile = ?, service_level = ?, last_seen = ? WHERE id = ?", CRM);
         jdbcTemplate.update(con -> {
             PreparedStatement ps = con.prepareStatement(sql);
             ps.setString(1, detailsDTO.getEmail());
             ps.setString(2, detailsDTO.getMobile());
             ps.setInt(3, detailsDTO.getServiceLevel());
             ps.setTimestamp(4, Timestamp.from(Instant.now()));
+            ps.setLong(5, userId);
             return ps;
         });
     }
 
     public UserCrm getUserProfileById(Long userId) {
-        String sql = String.format("SELECT * FROM %s WHERE user_id = ?", CRM);
-        String sqlUpdateLastSeen = String.format("UPDATE %s SET last_seen = %s WHERE user_id = ?", CRM, Timestamp.from(Instant.now()));
+        String sql = String.format("SELECT * FROM %s WHERE id = ?", CRM);
+        String sqlUpdateLastSeen = String.format("UPDATE %s SET last_seen = ? WHERE id = ?", CRM);
+        Timestamp now = Timestamp.from(Instant.now());
         UserCrm result = (UserCrm) jdbcTemplate.queryForObject(sql, new UserCrmMapper(), userId);
-        jdbcTemplate.update(sqlUpdateLastSeen, userId);
+        jdbcTemplate.update(sqlUpdateLastSeen, now, userId);
         return result;
     }
 }

--- a/src/main/java/com/reminder/Users/repository/UsersRepository.java
+++ b/src/main/java/com/reminder/Users/repository/UsersRepository.java
@@ -2,11 +2,14 @@ package com.reminder.Users.repository;
 
 import com.reminder.Users.model.UserCrm;
 import com.reminder.Users.model.UserLogin;
+import com.reminder.Users.model.UserUpdateDTO;
+import com.reminder.Users.repository.mapper.UserCrmMapper;
 import com.reminder.Users.repository.mapper.UserLoginMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
@@ -75,5 +78,25 @@ public class UsersRepository {
     public void updateLoginUserId(String userName, Long id) {
         String sql = String.format("UPDATE %s SET user_id = ?, is_active = true WHERE user_name = ?", LOGIN);
         jdbcTemplate.update(sql, id, userName);
+    }
+
+    public void updateMyProfile(String userName, UserUpdateDTO detailsDTO) {
+        String sql = String.format("UPDATE %s SET email_address = ?, mobile = ?, service_level = ?, last_seen = ? WHERE user_name = %s", CRM, userName);
+        jdbcTemplate.update(con -> {
+            PreparedStatement ps = con.prepareStatement(sql);
+            ps.setString(1, detailsDTO.getEmail());
+            ps.setString(2, detailsDTO.getMobile());
+            ps.setInt(3, detailsDTO.getServiceLevel());
+            ps.setTimestamp(4, Timestamp.from(Instant.now()));
+            return ps;
+        });
+    }
+
+    public UserCrm getUserProfileById(Long userId) {
+        String sql = String.format("SELECT * FROM %s WHERE user_id = ?", CRM);
+        String sqlUpdateLastSeen = String.format("UPDATE %s SET last_seen = %s WHERE user_id = ?", CRM, Timestamp.from(Instant.now()));
+        UserCrm result = (UserCrm) jdbcTemplate.queryForObject(sql, new UserCrmMapper(), userId);
+        jdbcTemplate.update(sqlUpdateLastSeen, userId);
+        return result;
     }
 }

--- a/src/main/java/com/reminder/Users/repository/mapper/UserCrmMapper.java
+++ b/src/main/java/com/reminder/Users/repository/mapper/UserCrmMapper.java
@@ -11,12 +11,13 @@ public class UserCrmMapper implements RowMapper {
     @Override
     public Object mapRow(ResultSet rs, int rowNum) throws SQLException {
         UserCrm user = new UserCrm();
+        user.setId(rs.getLong("id"));
         user.setGivenName(rs.getString("given_name"));
         user.setSurname(rs.getString("surname"));
-        user.setEmail(rs.getString("email"));
+        user.setEmail(rs.getString("email_address"));
         user.setMobile(rs.getString("mobile"));
         user.setServiceLevel(rs.getInt("service_level"));
         user.setLastSeen(rs.getTimestamp("last_seen").toInstant());
-        return null;
+        return user;
     }
 }

--- a/src/main/java/com/reminder/Users/repository/mapper/UserCrmMapper.java
+++ b/src/main/java/com/reminder/Users/repository/mapper/UserCrmMapper.java
@@ -1,0 +1,22 @@
+package com.reminder.Users.repository.mapper;
+
+import com.reminder.Users.model.UserCrm;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+
+public class UserCrmMapper implements RowMapper {
+    @Override
+    public Object mapRow(ResultSet rs, int rowNum) throws SQLException {
+        UserCrm user = new UserCrm();
+        user.setGivenName(rs.getString("given_name"));
+        user.setSurname(rs.getString("surname"));
+        user.setEmail(rs.getString("email"));
+        user.setMobile(rs.getString("mobile"));
+        user.setServiceLevel(rs.getInt("service_level"));
+        user.setLastSeen(rs.getTimestamp("last_seen").toInstant());
+        return null;
+    }
+}

--- a/src/main/java/com/reminder/Users/repository/mapper/UserLoginMapper.java
+++ b/src/main/java/com/reminder/Users/repository/mapper/UserLoginMapper.java
@@ -10,7 +10,7 @@ public class UserLoginMapper implements RowMapper {
     @Override
     public UserLogin mapRow(ResultSet rs, int rowNum) throws SQLException {
         UserLogin userLogin = new UserLogin();
-        userLogin.setUserId(rs.getLong("id"));
+        userLogin.setId(rs.getLong("id"));
         userLogin.setUserId(rs.getLong("user_id"));
         userLogin.setUserName(rs.getString("user_name"));
         userLogin.setHashedPassword(rs.getString("hashed_password"));

--- a/src/main/java/com/reminder/Users/service/UsersService.java
+++ b/src/main/java/com/reminder/Users/service/UsersService.java
@@ -3,6 +3,7 @@ package com.reminder.Users.service;
 import com.reminder.Users.model.TokensDTO;
 import com.reminder.Users.model.UserCrm;
 import com.reminder.Users.model.UserLogin;
+import com.reminder.Users.model.UserUpdateDTO;
 import com.reminder.Users.repository.UsersRepository;
 import com.reminder.security.CustomUserDetails;
 import com.reminder.Users.utilities.JwtUtil;
@@ -69,6 +70,24 @@ public class UsersService {
                 jwtUtil.generateRefreshToken(savedUser.getUserName(), savedUser.getRole()));
     }
 
+    public void updateMyProfile(String userName, UserUpdateDTO detailsDTO) {
+        validateUpdateDetails(detailsDTO);
+        detailsDTO.setServiceLevel(determineServiceLevel(detailsDTO.getEmail(), detailsDTO.getMobile()));
+        usersRepository.updateMyProfile(userName, detailsDTO);
+    }
+
+    public UserCrm viewMyProfile(String userName) {
+        UserLogin userLogin = usersRepository.getUserByUserName(userName);
+        return usersRepository.getUserProfileById(userLogin.getUserId());
+    }
+
+
+    /*
+                *****************
+                *Utility methods*
+                *****************
+     */
+
     private String passwordHasher(String rawPassword) {
         return encoder.encode(rawPassword);
     }
@@ -88,6 +107,13 @@ public class UsersService {
         if (!validEmail.matcher(user.getEmail()).matches() && user.getEmail() != null && !user.getEmail().isEmpty())
             throw new IllegalArgumentException("Invalid E-mail address");
         if (!validMobile.matcher(user.getMobile()).matches() && user.getMobile() != null && !user.getMobile().isEmpty())
+            throw new IllegalArgumentException("Mobile must be 10-15 digit long, may include state prefix without + or separators");
+    }
+
+    private void validateUpdateDetails(UserUpdateDTO details){
+        if (!validEmail.matcher(details.getEmail()).matches() && details.getEmail() != null && !details.getEmail().isEmpty())
+            throw new IllegalArgumentException("Invalid E-mail address");
+        if (!validMobile.matcher(details.getMobile()).matches() && details.getMobile() != null && !details.getMobile().isEmpty())
             throw new IllegalArgumentException("Mobile must be 10-15 digit long, may include state prefix without + or separators");
     }
 

--- a/src/main/java/com/reminder/security/AuthService.java
+++ b/src/main/java/com/reminder/security/AuthService.java
@@ -63,7 +63,6 @@ public class AuthService {
 
     public void setSecurityContext (AuthResponseDTO dto){
         Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
-        System.out.println(currentAuth);
         CustomUserDetails userDetails = userDetailService.loadUserByUsername(dto.getUserName());
         Authentication newAuth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         if (currentAuth != null) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,6 +29,7 @@ spring:
 logging:
   level:
     root: INFO
+
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} - %-5level %logger{36} - %msg%n"
     file: "%d{yyyy-MM-dd HH:mm:ss} - %-5level %logger{36} - %msg%n"

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -36,3 +36,5 @@ CREATE TABLE common_ip (
     is_sus BOOLEAN DEFAULT FALSE,
     FOREIGN KEY (user_id) REFERENCES user_login(id)
 );
+
+INSERT INTO user_login (user_name, hashed_password, role, is_active) VALUES ('_ping', '_ping', 'user', true);

--- a/src/test/java/com/reminder/Users/SelfServiceIntegrationTest.java
+++ b/src/test/java/com/reminder/Users/SelfServiceIntegrationTest.java
@@ -1,0 +1,130 @@
+package com.reminder.Users;
+
+import com.jayway.jsonpath.JsonPath;
+import com.reminder.Users.model.UserCrm;
+import com.reminder.Users.model.UserLogin;
+import com.reminder.Users.repository.UsersRepository;
+import com.reminder.Users.repository.mapper.UserCrmMapper;
+import com.reminder.Users.repository.mapper.UserLoginMapper;
+import com.reminder.Users.utilities.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class SelfServiceIntegrationTest {
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    BCryptPasswordEncoder encoder;
+    @Autowired
+    UsersRepository repo;
+    @Autowired
+    JdbcTemplate jdbc;
+    @Autowired
+    JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setup() {
+        jdbc.execute("DELETE FROM common_ip");
+        jdbc.execute("DELETE FROM user_login");
+        jdbc.execute("DELETE FROM user_crm");
+        String hashedPassword = encoder.encode("V@lidP@$$w0rd");
+        UserLogin userLogin = new UserLogin(null,null,"ValidUser1", hashedPassword, "user", false);
+        UserCrm userCrm = new UserCrm(null, "John", "Doe", null, null, 0, null);
+        repo.save(userLogin);
+        Long userId = repo.activate(userCrm);
+        repo.updateLoginUserId(userLogin.getUserName(), userId);
+    }
+
+    @Test
+    void testSetup () throws InterruptedException {
+        String sql = "SELECT * FROM user_crm";
+        String sql2 = "SELECT * FROM user_login";
+        System.out.println(jdbc.query(sql, new UserCrmMapper()));
+        System.out.println(jdbc.query(sql2, new UserLoginMapper()));
+    }
+
+    //Valid request
+    @Test
+    void happyPath () throws Exception {
+        String access = jwtUtil.generateJwtToken("ValidUser1", "user");
+        String refresh = jwtUtil.generateRefreshToken("ValidUser1", "user");
+        String update1 = "{\"email\": \"validmail@domain.com\"}";
+        String update2 = "{\"mobile\": \"0523214565\"}";
+
+        mockMvc.perform(get("/auth/self_service")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + access)
+                .header("Refresh", "Bearer " + refresh))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.givenName").value("John"));
+
+        mockMvc.perform(patch("/auth/self_service")
+                .contentType(MediaType.APPLICATION_JSON)
+                        .content(update1)
+                .header("Authorization", "Bearer " + access)
+                .header("Refresh", "Bearer " + refresh))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value("User updated"));
+
+        mockMvc.perform(get("/auth/self_service")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + access)
+                        .header("Refresh", "Bearer " + refresh))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.serviceLevel").value(2));
+
+        mockMvc.perform(patch("/auth/self_service")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(update2)
+                        .header("Authorization", "Bearer " + access)
+                        .header("Refresh", "Bearer " + refresh))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value("User updated"));
+
+        mockMvc.perform(get("/auth/self_service")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + access)
+                        .header("Refresh", "Bearer " + refresh))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.serviceLevel").value(3));
+    }
+
+    @Test
+    void updateInvalidFormat () throws Exception{
+        String access = jwtUtil.generateJwtToken("ValidUser1", "user");
+        String refresh = jwtUtil.generateRefreshToken("ValidUser1", "user");
+        String update1 = "{\"email\": \"invalidmail.domain.com\"}";
+        String update2 = "{\"mobile\": \"052-3214565\"}";
+
+        mockMvc.perform(patch("/auth/self_service")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(update1)
+                .header("Authorization", "Bearer " + access)
+                .header("Refresh", "Bearer " + refresh))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$").value("Invalid E-mail address"));
+
+        mockMvc.perform(patch("/auth/self_service")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(update2)
+                        .header("Authorization", "Bearer " + access)
+                        .header("Refresh", "Bearer " + refresh))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$").value("Mobile must be 10-15 digit long, may include state prefix without + or separators"));
+    }
+}


### PR DESCRIPTION
This PR introduces the self-service functionality for authenticated users, allowing them to view and update their profile (/auth/self_service). Key changes include:

- GET /auth/self_service: returns current user profile from user_crm
- PATCH /auth/self_service: updates email/mobile with input validation
- Refactored to extract userId from SecurityContext to avoid redundant DB queries
- Merges new input with existing profile data to preserve non-supplied fields
- Added integration tests covering valid/invalid update flows
- Added ADR003 and ADR004 documenting these design decisions